### PR TITLE
Fix bashisms

### DIFF
--- a/git-abort
+++ b/git-abort
@@ -1,23 +1,23 @@
-#!/bin/bash
+#!/bin/sh
 
 # Abort a rebase, merge, `am`, a cherry-pick or a revert, depending on the situation.
 
 set -e
 git_dir="$(git rev-parse --git-dir)"
 
-if [[ -e "${git_dir}/CHERRY_PICK_HEAD" ]] ; then
+if [ -e "${git_dir}/CHERRY_PICK_HEAD" ] ; then
     exec git cherry-pick --abort "$@"
-elif [[ -e "${git_dir}/REVERT_HEAD" ]] ; then
+elif [ -e "${git_dir}/REVERT_HEAD" ] ; then
     exec git revert --abort "$@"
-elif [[ -e "${git_dir}/rebase-apply/applying" ]] ; then
+elif [ -e "${git_dir}/rebase-apply/applying" ] ; then
     exec git am --abort "$@"
-elif [[ -e "${git_dir}/rebase-apply" ]] ; then
+elif [ -e "${git_dir}/rebase-apply" ] ; then
     exec git rebase --abort "$@"
-elif [[ -e "${git_dir}/rebase-merge" ]] ; then
+elif [ -e "${git_dir}/rebase-merge" ] ; then
     exec git rebase --abort "$@"
-elif [[ -e "${git_dir}/MERGE_MODE" ]] ; then
+elif [ -e "${git_dir}/MERGE_MODE" ] ; then
     exec git merge --abort "$@"
 else
-    echo git-abort: unknown state
-    exit -1
+    echo "git-abort: unknown state" >&2
+    exit 1
 fi

--- a/git-continue
+++ b/git-continue
@@ -1,20 +1,20 @@
-#!/bin/bash
+#!/bin/sh
 
 # Continue a rebase, `am`, a cherry-pick or a revert, depending on the situation.
 set -e
 
 git_dir="$(git rev-parse --git-dir)"
-if [[ -e "${git_dir}/CHERRY_PICK_HEAD" ]] ; then
+if [ -e "${git_dir}/CHERRY_PICK_HEAD" ] ; then
     exec git cherry-pick --continue "$@"
-elif [[ -e "${git_dir}/REVERT_HEAD" ]] ; then
+elif [ -e "${git_dir}/REVERT_HEAD" ] ; then
     exec git revert --continue "$@"
-elif [[ -e "${git_dir}/rebase-apply/applying" ]] ; then
+elif [ -e "${git_dir}/rebase-apply/applying" ] ; then
     exec git am --continue "$@"
-elif [[ -e "${git_dir}/rebase-apply" ]] ; then
+elif [ -e "${git_dir}/rebase-apply" ] ; then
     exec git rebase --continue "$@"
-elif [[ -e "${git_dir}/rebase-merge" ]] ; then
+elif [ -e "${git_dir}/rebase-merge" ] ; then
     exec git rebase --continue "$@"
 else
-    echo git-continue: unknown state
-    exit -1
+    echo "git-continue: unknown state" >&2
+    exit 1
 fi

--- a/git-new-project
+++ b/git-new-project
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/git-original-rev
+++ b/git-original-rev
@@ -1,13 +1,13 @@
-#!/bin/bash -ue
+#!/bin/sh -ue
 
 #
 # What is the commit we are trying to apply now during
 # rebase? This answers the question.
 #
 
-if [[ -e .git/rebase-apply/original-commit ]] ; then
+if [ -e .git/rebase-apply/original-commit ] ; then
     cat .git/rebase-apply/original-commit
     exit 0
 fi
 
-exit -2
+exit 1

--- a/git-remote-clone
+++ b/git-remote-clone
@@ -1,31 +1,29 @@
-#!/bin/bash -ue
+#!/bin/sh -ue
 
 if [ "$#" -ne 1 ] ; then
-    echo "Expected host:path"
-    exit -1
+    echo "Expected host:path" >&2
+    exit 1
 fi
 
-X="$1"
-arr=(`echo $X | tr ':' ' '`)
-
-dest=${arr[0]}
-remote_path=${arr[1]}
+IFS=: read dest remote_path << _END
+$1
+_END
 
 if [ -z "$dest" ] ; then
-    echo "Destination not specified"
-    exit -1
+    echo "Destination not specified" >&2
+    exit 1
 fi
 
 if [ -z "$remote_path" ] ; then
-    echo "Path on destination not specified"
-    exit -1
+    echo "Path on destination not specified" >&2
+    exit 1
 fi
 
 branch=master
 
-ssh -t ${dest} "mkdir -p ${remote_path} && cd ${remote_path} && git init" || exit -1
-ssh -t ${dest} "cd ${remote_path} && git config receive.denyCurrentBranch no" || exit -1
-ssh -t ${dest} "cd ${remote_path} && git init && touch nothing && git add nothing" || exit -1
-ssh -t ${dest} "cd ${remote_path} && git commit -m nothing --author='nothing <nothing@nothing.com>'" || exit -1
+ssh -t ${dest} "mkdir -p ${remote_path} && cd ${remote_path} && git init" || exit 1
+ssh -t ${dest} "cd ${remote_path} && git config receive.denyCurrentBranch no" || exit 1
+ssh -t ${dest} "cd ${remote_path} && git init && touch nothing && git add nothing" || exit 1
+ssh -t ${dest} "cd ${remote_path} && git commit -m nothing --author='nothing <nothing@nothing.com>'" || exit 1
 
 git-remote-push "$@"

--- a/git-remote-push
+++ b/git-remote-push
@@ -1,25 +1,22 @@
-#!/bin/bash -ue
+#!/bin/sh -ue
 
 if [ "$#" -eq 0 ] ; then
-    echo "Expected host:path"
-    exit -1
+    echo "Expected host:path" >&2
+    exit 1
 fi
 
-X="$1"
-shift 1
-arr=(`echo $X | tr ':' ' '`)
-
-dest=${arr[0]}
-remote_path=${arr[1]}
+IFS=: read dest remote_path << _END
+$1
+_END
 
 if [ -z "$dest" ] ; then
-    echo "Destination not specified"
-    exit -1
+    echo "Destination not specified" >&2
+    exit 1
 fi
 
 if [ -z "$remote_path" ] ; then
-    echo "Path on destination not specified"
-    exit -1
+    echo "Path on destination not specified" >&2
+    exit 1
 fi
 
 branch=master

--- a/git-set-email
+++ b/git-set-email
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 # Set my per-repository credentials using dirlocalenv.
 
 set -e
 
 dirname=$(basename $(pwd))
-email=$(dirlocalenv bash -c 'echo $EMAIL_SPHERE')
+email=$(dirlocalenv sh -c 'echo $EMAIL_SPHERE')
 git config user.email ${email}

--- a/git-skip
+++ b/git-skip
@@ -1,16 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
 # Skip a patch in a rebase or am, depending on the situation.
 set -e
 
 git_dir="$(git rev-parse --git-dir)"
-if [[ -e "${git_dir}/rebase-apply/applying" ]] ; then
+if [ -e "${git_dir}/rebase-apply/applying" ] ; then
     exec git am --skip "$@"
-elif [[ -e "${git_dir}/rebase-apply" ]] ; then
+elif [ -e "${git_dir}/rebase-apply" ] ; then
     exec git rebase --skip "$@"
-elif [[ -e "${git_dir}/rebase-merge" ]] ; then
+elif [ -e "${git_dir}/rebase-merge" ] ; then
     exec git rebase --skip "$@"
 else
-    echo git-continue: unknown state
-    exit -1
+    echo "git-continue: unknown state" >&2
+    exit 1
 fi


### PR DESCRIPTION
- Use [ instead of [[
- Use read instead of arrays
- Don't use `exit -1` (unportable)
- Switch to /bin/sh shebangs
- Output error messages to stderr instead of stdout

This may require additional testing, I haven't tested all commands
